### PR TITLE
Organization repos are now listed on the profile page.

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -17,7 +17,14 @@ class UsersController < ApplicationController
 
     def get_repos_list(user)
       repos = Github::Repos.new
-      repos.all user: user.github_id
+      repos = repos.all user: user.github_id
+
+      orgs = Github.orgs.all(user: user.github_id).collect { |o| o.login }
+      orgs.each do |o|
+        repos += Github.repos.all(user: o)
+      end
+
+      repos
     end
 
     def add_status(repos)


### PR DESCRIPTION
While organization repos are now listed, they are not separated in any way. I wasn't sure if that was preferable, so I left it as it is to open a discussion.

<!---
@huboard:{"order":80.0,"custom_state":""}
-->
