### PR TITLE
Bug fix for On/Off button

### DIFF
--- a/app/controllers/tagging_controller.rb
+++ b/app/controllers/tagging_controller.rb
@@ -2,12 +2,9 @@ class TaggingController < ApplicationController
 
   def update_tags
     @repo = Repo.find_by_github_id_and_user_id(params[:github_id], current_user.id)
-    need_help = @repo.nil? ? false : @repo.need_help
     @repo ||= Repo.init_repo(current_user, params[:repo_name], false)
     @repo.tag_list = params[:tag_list]
-    @repo.need_help = need_help
     @repo.save!
-
     respond_to do |format|
       format.js { @repo }
     end


### PR DESCRIPTION
Since you can only add tags to a Helped Repo, those lines are not necessary in the tagging controller anymore.
You asked if the On/Off button was working, the answer was YES, but... adding tags to a Helped repo was messing the helped status, this commit solves it.
