### PR TITLE
Fixed Repo model so the Repo#repo_attributes method can be called

### DIFF
--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -75,7 +75,7 @@ class Repo < ActiveRecord::Base
   
   private
   
-  def repo_attributes
+  def self.repo_attributes
     %w(name github_url need_help created_at updated_at full_name description language forks watchers open_issues pushed_at)
   end
 


### PR DESCRIPTION
The method was private but not static, the class itself could not call the method in order to populate attributes on the new repo being created.  I made it static.
