### PR TITLE
Updated rack to 1.4.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,7 +143,7 @@ GEM
     polyglot (0.3.3)
     quiet_assets (1.0.1)
       railties (~> 3.1)
-    rack (1.4.3)
+    rack (1.4.5)
     rack-cache (1.2)
       rack (>= 0.4)
     rack-ssl (1.3.2)


### PR DESCRIPTION
Protects agains potential timing attacks from CVE-2013-0263
