### PR TITLE
Secure secret token

### DIFF
--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -4,4 +4,8 @@
 # If you change this key, all old signed cookies will become invalid!
 # Make sure the secret is at least 30 characters and all random,
 # no regular words or you'll be exposed to dictionary attacks.
-ContribHub::Application.config.secret_token = '50574b3232c54a67a90c672733b0dadea06163a9aefe46cf0a35113b5e63f268cf6ca8b452d5bb5d6bb2cf823a3f902e5585040e44ed393de5a3c7dacbdcef46'
+ContribHub::Application.config.secret_token = if Rails.env.development? or Rails.env.test?
+  ('x' * 30) # meets minimum requirement of 30 chars long
+else
+  ENV['SECRET_TOKEN']
+end


### PR DESCRIPTION
Set ENV['SECRET_TOKEN'] in production mode, and use insecure token elsewhere. 

http://daniel.fone.net.nz/blog/2013/05/20/a-better-way-to-manage-the-rails-secret-token/
