### PR TITLE
Disable mouse wheel zoom on index page map

### DIFF
--- a/app/assets/javascripts/map.js.coffee
+++ b/app/assets/javascripts/map.js.coffee
@@ -6,6 +6,7 @@ map = null
 initialize_map = ->
   mapOptions =
     zoom: 2,
+    scrollwheel: false,
     mapTypeId: google.maps.MapTypeId.ROADMAP,
     center: map_center
 


### PR DESCRIPTION
The map zoom-in and zoom-out when trying to scroll the index page, mouse was disabled for the map, scale buttons are provided on the map in order to zoom in/out
